### PR TITLE
Add `.env.example` file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DB_USER=
+DB_PASS=
+DB_HOST=
+DB_NAME=


### PR DESCRIPTION
Some dummy didn't want new developers to be able to easily configure a `.env` file. This PR fixes that :)